### PR TITLE
[MARS-3433] update the margin for button group

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -672,7 +672,7 @@
         "origin": "AUTHORED",
         "exported": true
     },
-    "campgladiator.cgui/components/molecules/button-group@0.0.21": {
+    "campgladiator.cgui/components/molecules/button-group@0.0.22": {
         "files": [
             {
                 "name": "ButtonGroup.js",

--- a/src/App.js
+++ b/src/App.js
@@ -164,6 +164,10 @@ function App() {
 
       <Card style={{ padding: '20px' }}>
         <ButtonGroup
+          content={{ left: 'default left', right: 'default right' }}
+          style={{ padding: '10px 0' }}
+        />
+        <ButtonGroup
           primary
           content={{ left: 'default left', right: 'default right' }}
           defaultSelected="left"

--- a/src/components/molecules/ButtonGroup/ButtonGroup.scss
+++ b/src/components/molecules/ButtonGroup/ButtonGroup.scss
@@ -10,4 +10,8 @@
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
+
+  .cg-button:not(:first-child) {
+    margin-left: -2px;
+  }
 }


### PR DESCRIPTION
**The following must be included in every PR. Please check all items before submitting your request.
If an item can not be satisfied, please provide a brief explanation as to why the item is not included.**

- [x] Rebased from Master prior to creation of pull request
- [ ] Minimum 1 unit test that covers the component
- [x] All tests run and passed prior to creation of pull request
- [ ] Component added to bit.dev server
- [ ] New feature documentation added to bit.dev
- [x] Ran `yarn sync` to get most recent version of all components from bit.dev server
- [x] Sandbox example of your component added/updated to App.js

**Provide a brief description of your update:**

JIRA CARD - https://campgladiator.atlassian.net/browse/MARS-3433

The Button group had a spacing of 4px margin in total so have updated it to be 2px.

<img width="562" alt="Screenshot 2021-02-11 at 1 24 15 PM" src="https://user-images.githubusercontent.com/23071585/107612570-8a731e00-6c6c-11eb-939d-52c2cc99c27a.png">
<img width="502" alt="Screenshot 2021-02-11 at 1 24 43 PM" src="https://user-images.githubusercontent.com/23071585/107612572-8ba44b00-6c6c-11eb-8ae0-d13696cbd992.png">
